### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub's official certification program. First part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
Resolves #6 - Add the missing GitHub Skills activity that was announced by the principal.

## Changes
- Added "GitHub Skills" activity to the activities list
- Includes description referencing the official GitHub Certifications program
- Schedule: Mondays and Wednesdays, 3:30 PM - 4:30 PM
- Capacity: 25 participants
- Activity is now available for student registration

## Impact
Students can now register for the GitHub Skills certification program which supports college applications as announced by the principal.